### PR TITLE
Use notify instead of auto notify

### DIFF
--- a/lib/bugsnag/exception_notification.rb
+++ b/lib/bugsnag/exception_notification.rb
@@ -3,11 +3,12 @@ require 'exception_notifier'
 
 module ExceptionNotifier
   class BugsnagNotifier
-    def initialize(options)
+    def initialize(options={})
+      @defaults = options
     end
 
     def call(exception, options={})
-      Bugsnag.notify(exception)
+      Bugsnag.notify(exception, @defaults.merge(options))
     end
   end
 end

--- a/lib/bugsnag/exception_notification.rb
+++ b/lib/bugsnag/exception_notification.rb
@@ -7,7 +7,7 @@ module ExceptionNotifier
     end
 
     def call(exception, options={})
-      Bugsnag.auto_notify(exception)
+      Bugsnag.notify(exception)
     end
   end
 end

--- a/spec/exception_notifier/bugsnag_notifier_spec.rb
+++ b/spec/exception_notifier/bugsnag_notifier_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ExceptionNotifier::BugsnagNotifier do
     let(:exception) { RuntimeError.new }
 
     it do
-      expect(Bugsnag).to receive(:auto_notify).with(exception)
+      expect(Bugsnag).to receive(:notify).with(exception)
       described_class.new({}).call(exception)
     end
   end

--- a/spec/exception_notifier/bugsnag_notifier_spec.rb
+++ b/spec/exception_notifier/bugsnag_notifier_spec.rb
@@ -4,9 +4,24 @@ RSpec.describe ExceptionNotifier::BugsnagNotifier do
   describe '#call' do
     let(:exception) { RuntimeError.new }
 
-    it do
-      expect(Bugsnag).to receive(:notify).with(exception)
+    it 'calls Bugsnag#notify' do
+      expect(Bugsnag).to receive(:notify).with(exception, {})
       described_class.new({}).call(exception)
+    end
+
+    it 'calls Bugsnag#notify with default options' do
+      expect(Bugsnag).to receive(:notify).with(exception, severity: 'error')
+      described_class.new(severity: 'error').call(exception)
+    end
+
+    it 'calls Bugsnag#notify with options' do
+      expect(Bugsnag).to receive(:notify).with(exception, severity: 'error')
+      described_class.new({}).call(exception, severity: 'error')
+    end
+
+    it 'calls Bugsnag#notify with override options' do
+      expect(Bugsnag).to receive(:notify).with(exception, severity: 'error')
+      described_class.new(severity: 'info').call(exception, severity: 'error')
     end
   end
 end


### PR DESCRIPTION
Hi @koshigoe. Thanks for your awesome library. This is very useful :)
However, in my case it did not meet the requirement a bit...

## Requirements
I'd like to control whether to notify bugsnag with exception_notification. following example:

```ruby
opts = if ENV['USE_BUGSNAG']
         { :bugsnag => {} }
       else
         {
           :email => {
             :email_prefix => "[PREFIX] ",
             :sender_address => %{"notifier" <notifier@example.com>},
             :exception_recipients => %w{exceptions@example.com}
           }
         }
       end

Rails.application.config.middleware.use ExceptionNotification::Rack, opts
```

In this case, I would like to disable auto_notify because it does not notify when `ENV['USE_BUGSNAG'] = false`. However, since it uses auto_notify, it does not work well in this case.

## Solution
Use notify instead of auto_notify. Also, because the default severity is warning, we can set this as options.

