### PR TITLE
Support Bugsnag gem version 6

### DIFF
--- a/lib/bugsnag/exception_notification.rb
+++ b/lib/bugsnag/exception_notification.rb
@@ -3,12 +3,22 @@ require 'exception_notifier'
 
 module ExceptionNotifier
   class BugsnagNotifier
-    def initialize(options={})
-      @defaults = options
+    def initialize(options=nil, &default_block)
+      @default_options = options
+      @default_block = default_block
     end
 
-    def call(exception, options={})
-      Bugsnag.notify(exception, @defaults.merge(options))
+    def call(exception, options={}, &block)
+      merged_block = proc do |notification|
+        @default_block.call(notification) if @default_block
+        block.call(notification) if block
+      end
+
+      if @default_options
+        Bugsnag.notify(exception, @default_options.merge(options), &merged_block)
+      else
+        Bugsnag.notify(exception, &merged_block)
+      end
     end
   end
 end

--- a/spec/exception_notifier/bugsnag_notifier_spec.rb
+++ b/spec/exception_notifier/bugsnag_notifier_spec.rb
@@ -23,5 +23,42 @@ RSpec.describe ExceptionNotifier::BugsnagNotifier do
       expect(Bugsnag).to receive(:notify).with(exception, severity: 'error')
       described_class.new(severity: 'info').call(exception, severity: 'error')
     end
+
+    context 'with block(s)' do
+      let(:report) { double('Bugsnag::Report') }
+      let(:default_block) do
+        Proc.new do |report|
+        end
+      end
+      let(:passed_block) do
+        Proc.new do |report|
+        end
+      end
+
+      before do
+        allow(Bugsnag).to receive(:notify) do |exception, options, &block|
+          block.call report
+        end
+      end
+
+      it 'calls default block' do
+        notifier = described_class.new(&default_block)
+        expect(default_block).to receive(:call).with(report)
+        notifier.call(exception)
+      end
+
+      it 'calls default block and passed block' do
+        notifier = described_class.new(&default_block)
+        expect(default_block).to receive(:call).with(report)
+        expect(passed_block).to receive(:call).with(report)
+        notifier.call(exception, &passed_block)
+      end
+
+      it 'calls passed block' do
+        notifier = described_class.new
+        expect(passed_block).to receive(:call).with(report)
+        notifier.call(exception, &passed_block)
+      end
+    end
   end
 end


### PR DESCRIPTION
Since version 6, bugsnag gem does not support `options` argument. Use block instead.
See https://github.com/bugsnag/bugsnag-ruby/blob/master/UPGRADING.md#notifying


So this gem should support the block style. And this change does not remove `options` style for compatibility.