### PR TITLE
Support Bugsnag 6 correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle/
+/vendor/bundle
 /.yardoc
 /Gemfile.lock
 /_yardoc/

--- a/README.md
+++ b/README.md
@@ -23,9 +23,23 @@ Or install it yourself as:
 
 **NOTE: not use exception_notification's middleware.**
 
+```ruby
+ExceptionNotifier.add_notifier :bugsnag
+# or
+ExceptionNotifier.add_notifier :bugsnag, severity: 'error'
 ```
-ExceptionNotifier.register_exception_notifier(:bugsnag, {})
-ExceptionNotifier.notify_exception(RuntimeError.new('TEST'))
+
+```ruby
+begin
+  # some code...
+rescue => err
+  ExceptionNotifier.notify_exception(err)
+  # or
+  ExceptionNotifier.notify_exception(err, severity: 'error')
+  # or
+  ExceptionNotifier.notify_exception(err) do |report|
+    report.severity = 'error'
+  end
 ```
 
 ### NOTE

--- a/exception_notification-bugsnag.gemspec
+++ b/exception_notification-bugsnag.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
 
   spec.add_runtime_dependency 'exception_notification'
-  spec.add_runtime_dependency 'bugsnag'
+  spec.add_runtime_dependency 'bugsnag', '>= 6'
 end

--- a/lib/bugsnag/exception_notification.rb
+++ b/lib/bugsnag/exception_notification.rb
@@ -8,7 +8,7 @@ module ExceptionNotifier
     end
 
     def call(exception, options={}, &block)
-      options = @default_options.merge(options) if options
+      options = @default_options.merge(options)
 
       wrapped_block = proc do |report|
         options.each do |key, value|

--- a/lib/bugsnag/exception_notification.rb
+++ b/lib/bugsnag/exception_notification.rb
@@ -3,22 +3,22 @@ require 'exception_notifier'
 
 module ExceptionNotifier
   class BugsnagNotifier
-    def initialize(options=nil, &default_block)
-      @default_options = options
-      @default_block = default_block
+    def initialize(options=nil)
+      @default_options = options || {}
     end
 
     def call(exception, options={}, &block)
-      merged_block = proc do |notification|
-        @default_block.call(notification) if @default_block
-        block.call(notification) if block
+      options = @default_options.merge(options) if options
+
+      wrapped_block = proc do |report|
+        options.each do |key, value|
+          report.public_send("#{key}=", value)
+        end
+
+        block.call(report) if block
       end
 
-      if @default_options
-        Bugsnag.notify(exception, @default_options.merge(options), &merged_block)
-      else
-        Bugsnag.notify(exception, &merged_block)
-      end
+      Bugsnag.notify(exception, &wrapped_block)
     end
   end
 end

--- a/spec/exception_notifier/bugsnag_notifier_spec.rb
+++ b/spec/exception_notifier/bugsnag_notifier_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe ExceptionNotifier::BugsnagNotifier do
       described_class.new(severity: 'info').call(exception, severity: 'error')
     end
 
+    it 'calls Bugsnag#notify with invalid options' do
+      expect { described_class.new.call(exception, nil) }.to raise_error(TypeError)
+    end
+
     context 'with block(s)' do
       let(:passed_block) do
         proc do |report|

--- a/spec/exception_notifier/bugsnag_notifier_spec.rb
+++ b/spec/exception_notifier/bugsnag_notifier_spec.rb
@@ -3,61 +3,47 @@ require 'spec_helper'
 RSpec.describe ExceptionNotifier::BugsnagNotifier do
   describe '#call' do
     let(:exception) { RuntimeError.new }
+    let(:report) { instance_double('Bugsnag::Report') }
 
     it 'calls Bugsnag#notify' do
-      expect(Bugsnag).to receive(:notify).with(exception, {})
+      expect(Bugsnag).to receive(:notify).with(exception).and_yield(report)
       described_class.new({}).call(exception)
     end
 
     it 'calls Bugsnag#notify with default options' do
-      expect(Bugsnag).to receive(:notify).with(exception, severity: 'error')
+      expect(report).to receive(:severity=).with('error')
+      expect(Bugsnag).to receive(:notify).with(exception).and_yield(report)
       described_class.new(severity: 'error').call(exception)
     end
 
     it 'calls Bugsnag#notify with options' do
-      expect(Bugsnag).to receive(:notify).with(exception, severity: 'error')
+      expect(report).to receive(:severity=).with('error')
+      expect(Bugsnag).to receive(:notify).with(exception).and_yield(report)
       described_class.new({}).call(exception, severity: 'error')
     end
 
     it 'calls Bugsnag#notify with override options' do
-      expect(Bugsnag).to receive(:notify).with(exception, severity: 'error')
+      expect(report).to receive(:severity=).with('error')
+      expect(Bugsnag).to receive(:notify).with(exception).and_yield(report)
       described_class.new(severity: 'info').call(exception, severity: 'error')
     end
 
     context 'with block(s)' do
-      let(:report) { double('Bugsnag::Report') }
-      let(:default_block) do
-        Proc.new do |report|
-        end
-      end
       let(:passed_block) do
-        Proc.new do |report|
+        proc do |report|
+          report.add_tab :user, name: 'foo'
         end
       end
 
       before do
-        allow(Bugsnag).to receive(:notify) do |exception, options, &block|
+        allow(Bugsnag).to receive(:notify) do |_exception, &block|
           block.call report
         end
       end
 
-      it 'calls default block' do
-        notifier = described_class.new(&default_block)
-        expect(default_block).to receive(:call).with(report)
-        notifier.call(exception)
-      end
-
-      it 'calls default block and passed block' do
-        notifier = described_class.new(&default_block)
-        expect(default_block).to receive(:call).with(report)
-        expect(passed_block).to receive(:call).with(report)
-        notifier.call(exception, &passed_block)
-      end
-
       it 'calls passed block' do
-        notifier = described_class.new
         expect(passed_block).to receive(:call).with(report)
-        notifier.call(exception, &passed_block)
+        described_class.new.call(exception, &passed_block)
       end
     end
   end


### PR DESCRIPTION
Hi, this PR will work with Bugsnag 6 correctly. I'm happy if you would check it. 😊 

- `Bugsnag.notify` supports only block syntax (not hash).
  See [Bugsnag Upgrade Guide](https://github.com/bugsnag/bugsnag-ruby/blob/f8322960b5b2a9c7f9c60c2a68abddd9f24d5ec1/UPGRADING.md#notifying).

- Custom `ExceptionNotifier` class's constructor supports only `options` argument (not block).
  See [exception_notification's code](https://github.com/smartinez87/exception_notification/blob/ef2f3de924241288ef3dbbfaafa01636e3ea6876/lib/exception_notifier.rb#L125).

Example:

```ruby
ExceptionNotifier.add_notifier :bugsnag, { severity: 'error' }
```

```ruby
begin
  # some code...
rescue => err
  ExceptionNotifier.notify_exception(err)
  ExceptionNotifier.notify_exception(err, severity: 'error')
  ExceptionNotifier.notify_exception(err) do |report|
    report.severity = 'error'
  end
end
```

Thanks. Please give me any feedback! 🙇 