### PR TITLE
Ignore methods which `Bugsnag::Report` doesn't have

### DIFF
--- a/lib/bugsnag/exception_notification.rb
+++ b/lib/bugsnag/exception_notification.rb
@@ -12,7 +12,10 @@ module ExceptionNotifier
 
       wrapped_block = proc do |report|
         options.each do |key, value|
-          report.public_send("#{key}=", value)
+          accessor = "#{key}=".to_sym
+          if report.respond_to?(accessor)
+            report.public_send(accessor, value)
+          end
         end
 
         block.call(report) if block

--- a/spec/exception_notifier/bugsnag_notifier_spec.rb
+++ b/spec/exception_notifier/bugsnag_notifier_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe ExceptionNotifier::BugsnagNotifier do
       expect { described_class.new.call(exception, nil) }.to raise_error(TypeError)
     end
 
+    it 'ignores passed unknown options' do
+      expect(Bugsnag).to receive(:notify) do |_exception, &block|
+        block.call report
+      end
+      expect(report).to receive(:severity=).with('info')
+      described_class.new.call(exception, foo: 1, bar: 2, severity: 'info')
+    end
+
     context 'with block(s)' do
       let(:passed_block) do
         proc do |report|


### PR DESCRIPTION
`ExceptionNotifier.notify_exception()` can be passed some options which `Bugsnag::Report` doesn't have.

For example, in the Rack middleware an `env:` option can be passed, but `Bugsnag::Report` doesn't have a `env=` method.

> Bugsnag middleware error: undefined method `env=' for #<Bugsnag::Report:0x000055c7e7578078>

https://github.com/bugsnag/bugsnag-ruby/blob/46d345d93dcb715c977615d24b369da204ed7b72/lib/bugsnag/middleware_stack.rb#L101

```ruby
ExceptionNotifier.notify_exception(exception, :env => env)
```

https://github.com/smartinez87/exception_notification/blob/2443af19e4c7433c7439c6ff01922a54023b89dd/lib/exception_notification/rack.rb#L51