### PR TITLE
Ignore options which `Bugsnag::Report` doesn't have

### DIFF
--- a/lib/bugsnag/exception_notification.rb
+++ b/lib/bugsnag/exception_notification.rb
@@ -12,7 +12,9 @@ module ExceptionNotifier
 
       wrapped_block = proc do |report|
         options.each do |key, value|
-          report.public_send("#{key}=", value)
+          if report.instance_of?(Bugsnag::Report)
+            report.public_send("#{key}=", value)
+          end
         end
 
         block.call(report) if block


### PR DESCRIPTION
Call only `Bugsnag::Report` accessors via options.

See #9 

`Bugsnag::Report` accessors below:

https://github.com/bugsnag/bugsnag-ruby/blob/46d345d93dcb715c977615d24b369da204ed7b72/lib/bugsnag/report.rb#L3