### PR TITLE
Handle "Rack Env" object

### DIFF
--- a/lib/bugsnag/exception_notification.rb
+++ b/lib/bugsnag/exception_notification.rb
@@ -12,7 +12,20 @@ module ExceptionNotifier
 
       wrapped_block = proc do |report|
         options.each do |key, value|
-          report.public_send("#{key}=", value)
+          # NOTE: `:env` option can be passed as a Rack Env object by `ExceptionNotification::Rack`.
+          #       Bugsnag provides the way to report the Env object by default.
+          #
+          # See below:
+          # - https://github.com/smartinez87/exception_notification/blob/2443af19e4c7433c7439c6ff01922a54023b89dd/lib/exception_notification/rack.rb#L51
+          # - https://github.com/bugsnag/bugsnag-ruby/blob/46d345d93dcb715c977615d24b369da204ed7b72/lib/bugsnag/middleware/rack_request.rb#L74-L76
+          # - https://docs.bugsnag.com/platforms/ruby/rails/configuration-options/#send_environment
+          if key == :env
+            if report.configuration.send_environment
+              report.add_tab(:environment, value)
+            end
+          else
+            report.public_send("#{key}=", value)
+          end
         end
 
         block.call(report) if block

--- a/spec/exception_notifier/bugsnag_notifier_spec.rb
+++ b/spec/exception_notifier/bugsnag_notifier_spec.rb
@@ -50,5 +50,29 @@ RSpec.describe ExceptionNotifier::BugsnagNotifier do
         described_class.new.call(exception, &passed_block)
       end
     end
+
+    context 'with `:env` option' do
+      let(:rack_env) { { 'rack.version' => [1, 3] } }
+      let(:config) { instance_double('Bugsnag::Configuration') }
+
+      before do
+        allow(report).to receive(:configuration).and_return(config)
+        allow(Bugsnag).to receive(:notify) do |_exception, &block|
+          block.call report
+        end
+      end
+
+      it 'ignores the option' do
+        expect(config).to receive(:send_environment).and_return(false)
+        expect(report).not_to receive(:add_tab)
+        described_class.new.call(exception, env: rack_env)
+      end
+
+      it 'adds a tab for the option' do
+        expect(config).to receive(:send_environment).and_return(true)
+        expect(report).to receive(:add_tab).with(:environment, rack_env)
+        described_class.new.call(exception, env: rack_env)
+      end
+    end
   end
 end


### PR DESCRIPTION
`options[:key]` can be a Rack Env object by `ExceptionNotification::Rack`.

See https://github.com/smartinez87/exception_notification/blob/2443af19e4c7433c7439c6ff01922a54023b89dd/lib/exception_notification/rack.rb#L51

For example, `ExceptionNotifier::GoogleChatNotifier` handles `options[:env]`:

https://github.com/smartinez87/exception_notification/blob/2443af19e4c7433c7439c6ff01922a54023b89dd/lib/exception_notifier/google_chat_notifier.rb#L26

See also #9, #10 

Original idea is from https://github.com/pocke/exception_notification-bugsnag/pull/9#issuecomment-445699093.