### PR TITLE
Support Sidekiq & Resque

### DIFF
--- a/lib/bugsnag/exception_notification.rb
+++ b/lib/bugsnag/exception_notification.rb
@@ -12,19 +12,22 @@ module ExceptionNotifier
 
       wrapped_block = proc do |report|
         options.each do |key, value|
-          # NOTE: `:env` option can be passed as a Rack Env object by `ExceptionNotification::Rack`.
-          #       Bugsnag provides the way to report the Env object by default.
-          #
-          # See below:
-          # - https://github.com/smartinez87/exception_notification/blob/2443af19e4c7433c7439c6ff01922a54023b89dd/lib/exception_notification/rack.rb#L51
-          # - https://github.com/bugsnag/bugsnag-ruby/blob/46d345d93dcb715c977615d24b369da204ed7b72/lib/bugsnag/middleware/rack_request.rb#L74-L76
-          # - https://docs.bugsnag.com/platforms/ruby/rails/configuration-options/#send_environment
-          if key == :env
-            if report.configuration.send_environment
-              report.add_tab(:environment, value)
-            end
-          else
+          case
+          when support_rack?(key)
+            process_rack(report, value)
+          when support_sidekiq?(key, value)
+            process_sidekiq(report, value)
+          when support_resque?(key, value)
+            process_resque(report, value)
+
+          # Support any attributes.
+          when report.respond_to?("#{key}=")
             report.public_send("#{key}=", value)
+
+          # Just warn instead of an error because it's tough to support
+          # all data formats which ExceptionNotification may pass.
+          else
+            warn "#{self.class.name} does not know the data: `#{key.inspect}=>#{value.inspect}`"
           end
         end
 
@@ -32,6 +35,46 @@ module ExceptionNotifier
       end
 
       Bugsnag.notify(exception, &wrapped_block)
+    end
+
+    private
+
+    # `:env` option can be passed as a Rack Env object by `ExceptionNotification::Rack`.
+    # Bugsnag provides the way to report the Env object by default.
+    #
+    # @see https://github.com/smartinez87/exception_notification/blob/v4.3.0/lib/exception_notification/rack.rb#L51
+    # @see https://github.com/bugsnag/bugsnag-ruby/blob/v6.0.0/lib/bugsnag/middleware/rack_request.rb#L61-L63
+    # @see https://docs.bugsnag.com/platforms/ruby/rails/configuration-options/#send_environment
+    def support_rack?(key)
+      key == :env
+    end
+
+    def process_rack(report, value)
+      if report.configuration.send_environment
+        report.add_tab(:environment, value)
+      end
+    end
+
+    # Support Sidekiq data format.
+    #
+    # @see https://github.com/smartinez87/exception_notification/blob/v4.3.0/lib/exception_notification/sidekiq.rb#L28
+    def support_sidekiq?(key, value)
+      key == :data && value.is_a?(Hash) && value.include?(:sidekiq)
+    end
+
+    def process_sidekiq(report, value)
+      report.add_tab(:sidekiq, value[:sidekiq])
+    end
+
+    # Support Resque data format.
+    #
+    # @see https://github.com/smartinez87/exception_notification/blob/v4.3.0/lib/exception_notification/resque.rb#L20
+    def support_resque?(key, value)
+      key == :data && value.is_a?(Hash) && value.include?(:resque)
+    end
+
+    def process_resque(report, value)
+      report.add_tab(:resque, value[:resque])
     end
   end
 end


### PR DESCRIPTION
This aims to fix the error below:

```
Bugsnag middleware error: undefined method `data=' for #<Bugsnag::Report:0x00007fe4c86c22f8>

/app/vendor/bundle/ruby/2.5.0/gems/exception_notification-bugsnag-0.3.0/lib/bugsnag/exception_notification.rb:27:in `public_send'
/app/vendor/bundle/ruby/2.5.0/gems/exception_notification-bugsnag-0.3.0/lib/bugsnag/exception_notification.rb:27:in `block (2 levels) in call'
/app/vendor/bundle/ruby/2.5.0/gems/exception_notification-bugsnag-0.3.0/lib/bugsnag/exception_notification.rb:14:in `each'
/app/vendor/bundle/ruby/2.5.0/gems/exception_notification-bugsnag-0.3.0/lib/bugsnag/exception_notification.rb:14:in `block in call'
/app/vendor/bundle/ruby/2.5.0/gems/bugsnag-6.11.1/lib/bugsnag.rb:99:in `block in notify'
/app/vendor/bundle/ruby/2.5.0/gems/bugsnag-6.11.1/lib/bugsnag/middleware_stack.rb:89:in `block in run'
/app/vendor/bundle/ruby/2.5.0/gems/bugsnag-6.11.1/lib/bugsnag/middleware/callbacks.rb:14:in `call'
/app/vendor/bundle/ruby/2.5.0/gems/bugsnag-6.11.1/lib/bugsnag/middleware/rails3_request.rb:44:in `call'
/app/vendor/bundle/ruby/2.5.0/gems/bugsnag-6.11.1/lib/bugsnag/middleware/rack_request.rb:90:in `call'
/app/vendor/bundle/ruby/2.5.0/gems/bugsnag-6.11.1/lib/bugsnag/middleware_stack.rb:94:in `run'
/app/vendor/bundle/ruby/2.5.0/gems/bugsnag-6.11.1/lib/bugsnag.rb:91:in `notify'
/app/vendor/bundle/ruby/2.5.0/gems/exception_notification-bugsnag-0.3.0/lib/bugsnag/exception_notification.rb:34:in `call'
/app/vendor/bundle/ruby/2.5.0/gems/exception_notification-4.3.0/lib/exception_notifier.rb:117:in `fire_notification'
/app/vendor/bundle/ruby/2.5.0/gems/exception_notification-4.3.0/lib/exception_notifier.rb:58:in `block in notify_exception'
/app/vendor/bundle/ruby/2.5.0/gems/exception_notification-4.3.0/lib/exception_notifier.rb:57:in `each'
/app/vendor/bundle/ruby/2.5.0/gems/exception_notification-4.3.0/lib/exception_notifier.rb:57:in `notify_exception'
/app/vendor/bundle/ruby/2.5.0/gems/exception_notification-4.3.0/lib/exception_notification/sidekiq.rb:28:in `block (2 levels) in <main>'
/app/vendor/bundle/ruby/2.5.0/gems/sidekiq-5.2.5/lib/sidekiq/exception_handler.rb:20:in `block in handle_exception'
/app/vendor/bundle/ruby/2.5.0/gems/sidekiq-5.2.5/lib/sidekiq/exception_handler.rb:18:in `each'
/app/vendor/bundle/ruby/2.5.0/gems/sidekiq-5.2.5/lib/sidekiq/exception_handler.rb:18:in `handle_exception'
/app/vendor/bundle/ruby/2.5.0/gems/sidekiq-5.2.5/lib/sidekiq/processor.rb:177:in `rescue in process'
/app/vendor/bundle/ruby/2.5.0/gems/sidekiq-5.2.5/lib/sidekiq/processor.rb:153:in `process'
/app/vendor/bundle/ruby/2.5.0/gems/sidekiq-5.2.5/lib/sidekiq/processor.rb:83:in `process_one'
/app/vendor/bundle/ruby/2.5.0/gems/sidekiq-5.2.5/lib/sidekiq/processor.rb:71:in `run'
/app/vendor/bundle/ruby/2.5.0/gems/sidekiq-5.2.5/lib/sidekiq/util.rb:16:in `watchdog'
/app/vendor/bundle/ruby/2.5.0/gems/sidekiq-5.2.5/lib/sidekiq/util.rb:25:in `block in safe_thread'
```